### PR TITLE
Importing - schema and '--force' overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To run the tool, you need access to a local or remote PostgreSQL database with t
 - [PgRouting](https://pgrouting.org/), and
 - hstore (available by default).
 
+Refer to the [Prerequisities](#prerequisities) section for details on installing the required dependencies for importing data into the database.
 
 # Quick Start Guide
 After setting up the configuration file, your next step is to edit the `main.py` file to execute only the steps you need. Currently, the content of `main.py` includes Python wrappers for the provided SQL functions in the `SQL/` directory, an example of an argument parser, and a main execution pipeline, which may be of interest to you.
@@ -86,10 +87,10 @@ The road graph tool consists of a set of components that are responsible for ind
 
 ## OSM file processing and importing
 ### Prerequisities
-Before we can process and load data (can be downloaded at [Geofabrik](https://download.geofabrik.de/)) into the database, we'll need to obtain and install several libraries: 
+Before processing and loading data (can be downloaded at [Geofabrik](https://download.geofabrik.de/)) into the database, we'll need to install several libraries: 
 * psql (for PostgreSQL)
-* osmium: osmium-tool (macOS `brew install osmium-tool`, Ubuntu `apt install osmium-tool`)
-* osm2pgsql (macOS `brew install osm2pgsql`, Ubuntu (1.6.0 version) `apt install osm2pgsql`)
+* osmium: osmium-tool (macOS: `brew install osmium-tool`, Ubuntu: `apt install osmium-tool`)
+* osm2pgsql (macOS: `brew install osm2pgsql`, Ubuntu: `apt install osm2pgsql` for version 1.6.0) - the current version or RTG uses `osm2pgsql 2.0.0`, which is compatible with version `1.11.0`
 The PostgreSQL database needs PostGis extension in order to enable spatial and geographic capabilities within the database, which is essential for working with OSM data.
 Loading large OSM files to database is memory demanding so [documentation](https://osm2pgsql.org/doc/manual.html#system-requirements) suggests to have RAM of at least the size of the OSM file.
 

--- a/README.md
+++ b/README.md
@@ -112,13 +112,15 @@ python3 process_osm.py sr [input_file] -o [output_file]
 ```
 
 ### 2. Importing to database using Flex output
-The `process_osm.py` script also allows to import OSM data to the database using [osm2pgsql](https://osm2pgsql.org) tool configured by [Flex output](https://osm2pgsql.org/doc/manual.html#the-flex-output). Flex output allows more flexible configuration such as filtering logic and creating additional types (e.g. areas, boundary, multipolygons) and tables for various POIs (e.g. restaurants, themeparks) to get the desired output. To use it, we specify the Flex style file (Lua script) that has all the logic for processing data in OSM file.
+The primary function of  `process_osm.py` script is to import OSM data to the database using [osm2pgsql](https://osm2pgsql.org) tool configured by [Flex output](https://osm2pgsql.org/doc/manual.html#the-flex-output). Flex output allows more flexible configuration such as filtering logic and creating additional types (e.g. areas, boundary, multipolygons) and tables for various POIs (e.g. restaurants, themeparks) to get the desired output. To use it, we define the Flex style file (Lua script) that has all the logic for processing data in OSM file.
 
 The default style file for this project is `resources/lua_styles/default.lua`, which processes and all nodes, ways and relations without creating additional attributes (based on tags) into following tables: `nodes` (node_id, geom, tags), `ways` (way_id, geom, tags, nodes), `relations` (relation_id, tags, members).
 
+Use `u` flag to upload data into database.
 ```bash
 python3 process_osm.py u [input_file] [-l style_file]
 ```
+    > **WARNING:_** Running this command will overwrite existing data in the relevant table. If you wish to proceed, use `--force` flag to overwrite or create new schema for new data.
 
 * E.g. this command (described bellow) processes OSM file of Lithuania using Flex output and uploads it into database (all configurations should be provided in `config.ini` in top folder).
 ```bash

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The road graph tool consists of a set of components that are responsible for ind
 Before processing and loading data (can be downloaded at [Geofabrik](https://download.geofabrik.de/)) into the database, we'll need to install several libraries: 
 * psql (for PostgreSQL)
 * osmium: osmium-tool (macOS: `brew install osmium-tool`, Ubuntu: `apt install osmium-tool`)
-* osm2pgsql (macOS: `brew install osm2pgsql`, Ubuntu: `apt install osm2pgsql` for version 1.6.0) - the current version or RTG uses `osm2pgsql 2.0.0`, which is compatible with version `1.11.0`
+* osm2pgsql (macOS: `brew install osm2pgsql`, Ubuntu: `apt install osm2pgsql` for version 1.6.0) - the current version of RGT is currently compatible with both `2.0.0` and `1.11.0` versions of `osm2pgsql`.
 The PostgreSQL database needs PostGis extension in order to enable spatial and geographic capabilities within the database, which is essential for working with OSM data.
 Loading large OSM files to database is memory demanding so [documentation](https://osm2pgsql.org/doc/manual.html#system-requirements) suggests to have RAM of at least the size of the OSM file.
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ To execute the configured pipeline, follow these steps:
     If the server database requires password, store it to your home directory in `.pgpass` (Ubuntu/MacOS, [Windows](https://www.postgresql.org/docs/current/libpq-pgpass.html)) file in following format: `hostname:port:database:username:password`.
 
     To start importing, run the `main.py` script with with `-i` or `--import`flag. This triggers [import_osm_to_db()](python/scripts/process_osm.py) function, which requires the OSM file path as an argument. 
-    > **_NOTE:_** To ensure the SSH tunnel is correctly set up for a remote database, provide `ssh` details in [config-EXAMPLE.ini](./config-EXAMPLE.ini).
-    - SSH tunnel setup is handled with [set_ssh_to_db_server_and_set_port()](python/roadgraphtool/db.py).
+    > **_NOTE:_** To ensure the SSH tunnel is correctly set up for a remote database, provide `ssh` details in [config-EXAMPLE.ini](./config-EXAMPLE.ini). SSH tunnel setup is handled with [set_ssh_to_db_server_and_set_port()](python/roadgraphtool/db.py).
     
     A style file path can also be provided - if omitted, the default style file [default.lua](resources/lua_styles/default.lua) is used. To customize the style file, define a new path for the [DEFAULT_STYLE_FILE](python/scripts/process_osm.py).
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Use `u` flag to upload data into database.
 ```bash
 python3 process_osm.py u [input_file] [-l style_file]
 ```
-    > **WARNING:_** Running this command will overwrite existing data in the relevant table. If you wish to proceed, use `--force` flag to overwrite or create new schema for new data.
+> **_WARNING:_** Running this command will overwrite existing data in the relevant table (these tables are specified in [schema.py](python/roadgraphtool/schema.py)). If you wish to proceed, use `--force` flag to overwrite or create new schema for new data.
 
-* E.g. this command (described bellow) processes OSM file of Lithuania using Flex output and uploads it into database (all configurations should be provided in `config.ini` in top folder).
+E.g. this command (described bellow) processes OSM file of Lithuania using Flex output and uploads it into database (all configurations should be provided in `config.ini` in top folder).
 ```bash
 # runs with default.lua
 python3 process_osm.py u lithuania-latest.osm.pbf

--- a/python/roadgraphtool/schema.py
+++ b/python/roadgraphtool/schema.py
@@ -23,23 +23,12 @@ def get_connection(config: CredentialsConfig) -> Optional['connection']:
     except psycopg2.DatabaseError as error:
         raise Exception(f"Error connecting to the database: {str(error)}")
 
-def schema_exists(schema: str, config: CredentialsConfig) -> bool:
-    """Returns True if a schema exists in the database."""
-    try:
-        with get_connection(config) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT schema_name FROM information_schema.schemata WHERE schema_name = %s;", (schema,))
-                res = cur.fetchone()
-                return res is not None
-    except (psycopg2.DatabaseError, Exception) as error:
-        raise Exception(f"Error: {str(error)}")
-
 def create_schema(schema: str, config: CredentialsConfig):
     """Creates a new schema in the database."""
     try:
         with get_connection(config) as conn:
             with conn.cursor() as cur:
-                query = f'CREATE SCHEMA "{schema}";'
+                query = f'CREATE SCHEMA if not exists "{schema}";'
                 cur.execute(query)
     except (psycopg2.DatabaseError, Exception) as error:
         raise Exception(f"Error: {str(error)}")

--- a/python/roadgraphtool/schema.py
+++ b/python/roadgraphtool/schema.py
@@ -49,7 +49,7 @@ def add_postgis_extension(schema: str, config: CredentialsConfig):
     try:
         with get_connection(config) as conn:
             with conn.cursor() as cur:
-                query = f'CREATE EXTENSION postgis SCHEMA "{schema}";'
+                query = f'CREATE EXTENSION if not exists postgis SCHEMA "{schema}";'
                 cur.execute(query)
     except (psycopg2.DatabaseError, Exception) as error:
         raise Exception(f"Error: {str(error)}")

--- a/python/roadgraphtool/schema.py
+++ b/python/roadgraphtool/schema.py
@@ -32,7 +32,7 @@ def schema_exists(schema: str, config: CredentialsConfig) -> bool:
                 res = cur.fetchone()
                 return res is not None
     except (psycopg2.DatabaseError, Exception) as error:
-        return str(error)
+        raise Exception(f"Error: {str(error)}")
 
 def create_schema(schema: str, config: CredentialsConfig):
     """Creates a new schema in the database."""
@@ -42,7 +42,7 @@ def create_schema(schema: str, config: CredentialsConfig):
                 query = f'CREATE SCHEMA "{schema}";'
                 cur.execute(query)
     except (psycopg2.DatabaseError, Exception) as error:
-        return str(error)
+        raise Exception(f"Error: {str(error)}")
     
 def add_postgis_extension(schema: str, config: CredentialsConfig):
     """Adds the PostGIS extension to the specified schema."""
@@ -52,7 +52,7 @@ def add_postgis_extension(schema: str, config: CredentialsConfig):
                 query = f'CREATE EXTENSION postgis SCHEMA "{schema}";'
                 cur.execute(query)
     except (psycopg2.DatabaseError, Exception) as error:
-        return str(error)
+        raise Exception(f"Error: {str(error)}")
 
 def  check_empty_or_nonexistent_tables(schema: str, config: CredentialsConfig) -> bool:
     """Return True, if tables (nodes, ways) are empty or non-existent."""
@@ -71,4 +71,4 @@ def  check_empty_or_nonexistent_tables(schema: str, config: CredentialsConfig) -
                             return False
         return True
     except (psycopg2.DatabaseError, Exception) as error:
-        return str(error)
+        raise Exception(f"Error: {str(error)}")

--- a/python/scripts/main.py
+++ b/python/scripts/main.py
@@ -154,6 +154,13 @@ def configure_arg_parser() -> argparse.ArgumentParser:
         help="Optional schema argument for -i/--import. Default is 'public' otherwise.",
         required=False
     )
+    parser.add_argument(
+        '--force',
+        dest='force',
+        action="store_true",
+        help="Force overwrite of data in existing tables in schema.",
+        required=False
+    )
 
     return parser
 
@@ -163,7 +170,7 @@ def main(arg_list: list[str] | None = None):
     args = parser.parse_args(arg_list)
 
     if args.importing:
-        import_osm_to_db(args.input_file, args.style_file, args.schema)
+        import_osm_to_db(args.input_file, args.force, args.style_file, args.schema)
     
     area_id = args.area_id
     area_srid = args.area_srid

--- a/python/scripts/process_osm.py
+++ b/python/scripts/process_osm.py
@@ -66,7 +66,7 @@ def run_osm2pgsql_cmd(config: CredentialsConfig, input_file: str, style_file_pat
     add_postgis_extension(schema, config)
 
     cmd = ["osm2pgsql", "-d", config.db_name, "-U", config.username, "-W", "-H", config.db_host, 
-               "-P", str(ssh_tunnel_port), "--output=flex", "-S", style_file_path, input_file, "-x"]
+               "-P", str(ssh_tunnel_port), "--output=flex", "-S", style_file_path, input_file, "-x", f"--schema={schema}"]
     if coords:
         cmd.extend(["-b", coords])
 

--- a/python/scripts/process_osm.py
+++ b/python/scripts/process_osm.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import logging
 
-from roadgraphtool.credentials_config import CREDENTIALS as config, CredentialsConfig
+from roadgraphtool.credentials_config import CREDENTIALS, CredentialsConfig
 from scripts.filter_osm import InvalidInputError, MissingInputError, load_multipolygon_by_id, is_valid_extension, setup_logger
 from scripts.find_bbox import find_min_max
 from roadgraphtool.db import db
@@ -49,7 +49,7 @@ def run_osmium_cmd(flag: str, input_file: str, output_file: str = None):
                     logger.info("Renumbering of OSM data completed.")
             os.remove(tmp_file)
 
-def run_osm2pgsql_cmd(config: CredentialsConfig, input_file: str, style_file_path: str, schema: str, coords: str| list[int] = None):
+def run_osm2pgsql_cmd(config: CredentialsConfig, input_file: str, style_file_path: str, schema: str, force: bool, coords: str| list[int] = None):
     """Import data from input_file to database specified in config using osm2pgsql tool."""
 
     if hasattr(config, "server"): # remote connection
@@ -57,6 +57,9 @@ def run_osm2pgsql_cmd(config: CredentialsConfig, input_file: str, style_file_pat
         db.set_ssh_to_db_server_and_set_port()
     else:  # local connection
         ssh_tunnel_port = config.db_server_port
+
+    if not force and not check_empty_or_nonexistent_tables(schema, config):
+        raise TableNotEmptyError("Attempt to overwrite non-empty tables. Use '--force' flag to proceed.")
 
     if not schema_exists(schema, config):
         create_schema(schema, config)
@@ -76,7 +79,7 @@ def run_osm2pgsql_cmd(config: CredentialsConfig, input_file: str, style_file_pat
     if not res.returncode:
         logger.info("Importing completed.")
 
-def import_osm_to_db(input_file: str, style_file_path: str = None, schema: str = "public") -> int:
+def import_osm_to_db(input_file: str, force: bool, style_file_path: str = None, schema: str = "public") -> int:
     """Return the size of OSM file in bytes if file found and imports OSM file do database specified in config.ini file.
 
     The **default.lua** style file is used if not specified or set otherwise.
@@ -89,7 +92,7 @@ def import_osm_to_db(input_file: str, style_file_path: str = None, schema: str =
         style_file_path = DEFAULT_STYLE_FILE
     if not os.path.exists(style_file_path):
         raise FileNotFoundError(f"Style file {style_file_path} does not exist.")
-    run_osm2pgsql_cmd(config, input_file, style_file_path, schema)
+    run_osm2pgsql_cmd(CREDENTIALS, input_file, style_file_path, schema, force)
     return file_size
 
 def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
@@ -112,7 +115,8 @@ b  : Extract greatest bounding box from given relation ID of
     parser.add_argument("-l", dest="style_file", nargs='?', default="resources/lua_styles/default.lua", help="Path to style file (optional for 'b', 'u' flag)")
     parser.add_argument("-o", dest="output_file", help="Path to output file (required for 's', 'r', 'sr' flag)")
     parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", help="Enable verbose output (DEBUG level logging)")
-    parser.add_argument("-sch", "--schema", dest="schema", default="public", help="Database schema (required for 'b', 'u' tag)")
+    parser.add_argument("-sch", "--schema", dest="schema", default="public", help="Database schema (for 'b', 'u' flag)")
+    parser.add_argument("--force", dest="force", action="store_true", help="Force overwrite of data in existing tables in schema (for 'b', 'u' flag)")
 
     args = parser.parse_args(arg_list)
 
@@ -125,6 +129,7 @@ b  : Extract greatest bounding box from given relation ID of
 
 def main(arg_list: list[str] | None = None):
     args = parse_args(arg_list)
+    print(args)
 
     if not os.path.exists(args.input_file):
         raise FileNotFoundError(f"File '{args.input_file}' does not exist.")
@@ -149,7 +154,7 @@ def main(arg_list: list[str] | None = None):
     
         case "u":
             # Upload OSM file to PostgreSQL database
-            run_osm2pgsql_cmd(config, args.input_file, args.style_file, args.schema)
+            run_osm2pgsql_cmd(CREDENTIALS, args.input_file, args.style_file, args.schema, args.force)
         case "b":
             # Extract bounding box based on relation ID and import to PostgreSQL
             if not args.relation_id:
@@ -158,7 +163,7 @@ def main(arg_list: list[str] | None = None):
             min_lon, min_lat, max_lon, max_lat = extract_bbox(args.relation_id)
             coords = f"{min_lon},{min_lat},{max_lon},{max_lat}"
 
-            run_osm2pgsql_cmd(config, args.input_file, args.style_file, args.schema, coords)
+            run_osm2pgsql_cmd(CREDENTIALS, args.input_file, args.style_file, args.schema, args.force, coords)
     
 if __name__ == '__main__':
     main()

--- a/python/scripts/process_osm.py
+++ b/python/scripts/process_osm.py
@@ -129,7 +129,6 @@ b  : Extract greatest bounding box from given relation ID of
 
 def main(arg_list: list[str] | None = None):
     args = parse_args(arg_list)
-    print(args)
 
     if not os.path.exists(args.input_file):
         raise FileNotFoundError(f"File '{args.input_file}' does not exist.")

--- a/python/scripts/process_osm.py
+++ b/python/scripts/process_osm.py
@@ -61,8 +61,7 @@ def run_osm2pgsql_cmd(config: CredentialsConfig, input_file: str, style_file_pat
     if not force and not check_empty_or_nonexistent_tables(schema, config):
         raise TableNotEmptyError("Attempt to overwrite non-empty tables. Use '--force' flag to proceed.")
 
-    if not schema_exists(schema, config):
-        create_schema(schema, config)
+    create_schema(schema, config)
     add_postgis_extension(schema, config)
 
     cmd = ["osm2pgsql", "-d", config.db_name, "-U", config.username, "-W", "-H", config.db_host, 

--- a/python/tests/test_process_osm.py
+++ b/python/tests/test_process_osm.py
@@ -99,7 +99,7 @@ def test_run_osm2pgsql_cmd(db_connection):
     style_file_path = str(parent_dir) + "/data/mock_default.lua"
     input_file = str(parent_dir) + "/data/bbox_test.osm"
 
-    run_osm2pgsql_cmd(config, input_file, style_file_path, 'osm_testing')
+    run_osm2pgsql_cmd(config, input_file, style_file_path, 'osm_testing', True)
 
     cursor = db_connection.cursor()
     cursor.execute('SELECT COUNT(*) FROM mocknodes;')
@@ -175,14 +175,14 @@ def test_import_to_db_valid(mocker):
     mocker.patch('scripts.process_osm.os.path.exists', side_effect=lambda path: path in ["resources/to_import.osm", 'resources/lua_styles/default.lua'])
     mocker.patch('os.path.getsize', return_value=1)
     mock_run_osm2pgsql_cmd = mocker.patch('scripts.process_osm.run_osm2pgsql_cmd')
-    file_size = import_osm_to_db('resources/to_import.osm', schema='osm_testing')
-    mock_run_osm2pgsql_cmd.assert_called_once_with(config, 'resources/to_import.osm', 'resources/lua_styles/default.lua', 'osm_testing')
+    file_size = import_osm_to_db('resources/to_import.osm', True, schema='osm_testing')
+    mock_run_osm2pgsql_cmd.assert_called_once_with(config, 'resources/to_import.osm', 'resources/lua_styles/default.lua', 'osm_testing', True)
     assert file_size == 1
 
 def test_import_to_db_invalid_file(mocker):
     mocker.patch('scripts.process_osm.os.path.exists', side_effect=lambda path: path == 'resources/lua_styles/default.lua')
     with pytest.raises(FileNotFoundError, match="No valid file to import was found."):
-        import_osm_to_db('resources/to_import.osm')
+        import_osm_to_db('resources/to_import.osm', False)
 
 def test_main_invalid_inputfile():
     arg_list = ["d", "invalid_file.osm"]
@@ -223,14 +223,14 @@ def test_main_default_style_valid(mocker):
         arg_list = ["u", tmp_file.name]
         mock_run_osm2pgsql_cmd = mocker.patch('scripts.process_osm.run_osm2pgsql_cmd')
         main(arg_list)
-        mock_run_osm2pgsql_cmd.assert_called_once_with(config, arg_list[1], "resources/lua_styles/default.lua", "public")
+        mock_run_osm2pgsql_cmd.assert_called_once_with(config, arg_list[1], "resources/lua_styles/default.lua", "public", False)
 
 def test_main_input_style_valid(mocker):
     with tempfile.NamedTemporaryFile(suffix=".osm") as tmp_input, tempfile.NamedTemporaryFile(suffix=".lua") as tmp_lua:
         arg_list = ["u", tmp_input.name, "-l", tmp_lua.name]
         mock_run_osm2pgsql_cmd = mocker.patch('scripts.process_osm.run_osm2pgsql_cmd')
         main(arg_list)
-        mock_run_osm2pgsql_cmd.assert_called_once_with(config, arg_list[1], arg_list[3], "public")
+        mock_run_osm2pgsql_cmd.assert_called_once_with(config, arg_list[1], arg_list[3], "public", False)
 
 def test_main_style_file_invalid():
     with tempfile.NamedTemporaryFile(suffix=".osm") as tmp_file:
@@ -251,7 +251,7 @@ def test_main_bbox_valid(mocker):
         mock_run_osm2pgsql_cmd = mocker.patch('scripts.process_osm.run_osm2pgsql_cmd')
         main(arg_list)
         mock_extract_bbox.assert_called_once_with(arg_list[3])
-        mock_run_osm2pgsql_cmd.assert_called_once_with(config, arg_list[1], "resources/lua_styles/default.lua", "public", "10,20,30,40")
+        mock_run_osm2pgsql_cmd.assert_called_once_with(config, arg_list[1], "resources/lua_styles/default.lua", "public", False, "10,20,30,40")
 
 # relation_id missing
 def test_main_bbox_id_missing():


### PR DESCRIPTION
Add schema option for OSM data importing and `--force` flag to overwrite data in database if the tables (specified in [schema.py](https://github.com/aicenter/road-graph-tool/blob/importer/python/roadgraphtool/schema.py#L8)) aren't empty.